### PR TITLE
Add ability to set breakpoints using MFA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ _build
 *.iml
 rebar3.crashdump
 rebar.lock
+/.tool-versions

--- a/README.md
+++ b/README.md
@@ -19,8 +19,10 @@ rebar3 shell
 1> application:ensure_all_started(cedb).
 2> % Set a breakpoint in `test.erl` module in line `16`
 2> cedb:break(test, 16).
-3> % run the application to debug
-3> test:start().
+3> % Set a breakpoint in `test.erl` module `function2` with arity `1`
+3> cedb:break(test, function2, 1).
+4> % run the application to debug
+4> test:start().
 
 => {<0.258.0>,{attached,test,16,false}}
 
@@ -30,7 +32,7 @@ File /projects/cedb/examples/test/_build/default/lib/test/src/test.erl
    12:       io:format("Finish~n").
    13:
    14:     function1() ->
-   15:       A = "Hello",
+  *15:       A = "Hello",
    16:       B = #{A => <<"c">>},
    17:       function2(B),
    18:       io:format("I'm in function 1~n").
@@ -38,6 +40,29 @@ File /projects/cedb/examples/test/_build/default/lib/test/src/test.erl
    20:     function2(C) ->
    21:       io:format("I'm in function 2, the value is ~p~n", [C]),
 
+cedb> next.
+ok 
+=> {<0.258.0>,running}
+
+File /projects/cedb/examples/test/_build/default/lib/test/src/test.erl
+
+   11:       function1(),
+   12:       io:format("Finish~n").
+   13:
+   14:     function1() ->
+   15:       A = "Hello",
+  *16:       B = #{A => <<"c">>},
+   17:       function2(B),
+   18:       io:format("I'm in function 1~n").
+   19:
+   20:     function2(C) ->
+   21:       io:format("I'm in function 2, the value is ~p~n", [C]),
+
+cedb> A.
+"Hello"
+cedb> n.
+ok 
+=> {<0.258.0>,running}
 cedb>
 ```
 
@@ -51,10 +76,13 @@ Command      | Description
 backtrace    | Show backtrace.
 bindings     | Show binded variables.
 continue     | Continue the execution of the process.
-finish       | Finis the debug session.
+finish       | Finish the debug session.
 messages     | Show process messages.
 next         | Execute next instruction.
 skip         | Skip.
 step         | Step inside next instruction.
 stop         | Stop debugging.
 timeout      | Timeout.
+Var          | Variable names are evaluated in the current context.
+
+Abbreviations of the above commands are also accepted, like `n` for `next`, `ba` for `backtrace` etc.


### PR DESCRIPTION
Working with raw line numbers can be inconvenient, so added the ability to do
`cedb:break(Module, Function, Arity)`

Plus 2 REPL convenience items:
 - recognize command abbreviations
 - evaluate variable bindings

Thanks!